### PR TITLE
Update to make the symex_lib no_std

### DIFF
--- a/crates/symex_lib/src/any.rs
+++ b/crates/symex_lib/src/any.rs
@@ -1,5 +1,4 @@
 use super::symbolic;
-use std::mem::MaybeUninit;
 
 pub trait Any {
     fn any() -> Self;
@@ -39,7 +38,7 @@ blanket_impl!(isize);
 
 fn internal_any<T: Any>() -> T {
     unsafe {
-        let mut a = MaybeUninit::uninit();
+        let mut a = core::mem::MaybeUninit::uninit();
         symbolic(&mut a);
         a.assume_init()
     }

--- a/crates/symex_lib/src/lib.rs
+++ b/crates/symex_lib/src/lib.rs
@@ -1,3 +1,4 @@
+#![no_std]
 mod any;
 
 pub use any::{any, Any};
@@ -93,7 +94,7 @@ impl<T> Valid for &T {
 /// being found.
 #[inline(never)]
 pub fn ignore_path() -> ! {
-    unsafe { std::hint::unreachable_unchecked() }
+    unsafe { core::hint::unreachable_unchecked() }
 }
 
 /// Try and trick the optimizer.


### PR DESCRIPTION
# symex_lib uses std when core can be used

This PR aims to solve the issue mentioned in #2, which is that the std lib is used when the core library is sufficient. Limiting the crate to the core will allow the analysis of embedded code.

closes #2