### PR TITLE
symex_lib::any cleanup

### DIFF
--- a/crates/symex_lib/Cargo.toml
+++ b/crates/symex_lib/Cargo.toml
@@ -5,4 +5,3 @@ edition = "2021"
 
 [dependencies]
 valid_derive = { path = "../valid_derive", version = "*" }
-paste = "1.0.11"

--- a/crates/symex_lib/Cargo.toml
+++ b/crates/symex_lib/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2021"
 
 [dependencies]
 valid_derive = { path = "../valid_derive", version = "*" }
+paste = "1.0.11"

--- a/crates/symex_lib/src/any.rs
+++ b/crates/symex_lib/src/any.rs
@@ -1,45 +1,63 @@
+//! Any
+//! ---
+//!
+//! This file defines and exports the [`Any`] trait.
+//! This trait provides an interface that allows the user to create a new [`symbolic`] without any prior [`assumptions`](crate::assume) of its value.
 use super::symbolic;
 
+/// Any
+/// ---
+///
+/// The implementers of this trait can be represented as a symbolic value.
+/// # Example implementation
+/// ```no_run
+/// impl Any for u8 {
+///     /// Generates a symbolic value a without any assumption of the value.
+///     fn any() -> u8{
+///         unsafe{
+///             let mut a = core::mem::MaybeUninit::uninit();
+///             symex_lib::symbolic(&mut a);
+///             a.assume_init()
+///         }
+///     }
+/// }
+/// ```
 pub trait Any {
     fn any() -> Self;
 }
 
+/// any
+/// ---
+///
+/// Returns a new symbolic value of a type that implements [`Any`].
+/// The symbolic value returned should have no [`assumptions`](crate::assume`) placed on it after the function returns.
 #[inline(never)]
 pub fn any<T: Any>() -> T {
     T::any()
 }
 
-macro_rules! blanket_impl {
-    ( $type: ty) => {
-        impl Any for $type {
-            #[inline(always)]
-            fn any() -> Self {
-                internal_any()
-            }
+/// Implements the [`Any`] trait for the specified types.
+///
+/// The blanket implementation provides a method [`any`] that creates a [`uninit`](core::mem::MaybeUninit) value
+/// that is converted to a [`symbolic`] value which is then assumed to be initialized to make the compiler happy.
+#[macro_export]
+macro_rules! impl_primitive {
+    ( $($type: ty),+) => {
+        paste::paste!{$(
+                impl Any for $type {
+                    #[doc = "Generates a new symbolic value of type [`"[<$type>]"`] value from uninitialized memory"]
+                    #[inline(always)]
+                    fn any() -> Self {
+                        unsafe {
+                            let mut a = core::mem::MaybeUninit::uninit();
+                            symbolic(&mut a);
+                            a.assume_init()
+                        }
+                    }
+                }
+            )+
         }
     };
 }
 
-blanket_impl!(bool);
-
-blanket_impl!(u8);
-blanket_impl!(u16);
-blanket_impl!(u32);
-blanket_impl!(u64);
-blanket_impl!(u128);
-blanket_impl!(usize);
-
-blanket_impl!(i8);
-blanket_impl!(i16);
-blanket_impl!(i32);
-blanket_impl!(i64);
-blanket_impl!(i128);
-blanket_impl!(isize);
-
-fn internal_any<T: Any>() -> T {
-    unsafe {
-        let mut a = core::mem::MaybeUninit::uninit();
-        symbolic(&mut a);
-        a.assume_init()
-    }
-}
+impl_primitive!(bool, u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize);

--- a/crates/symex_lib/src/any.rs
+++ b/crates/symex_lib/src/any.rs
@@ -26,6 +26,11 @@ pub trait Any {
 /// ---
 ///
 /// The symbolic value returned should have no [`assumptions`](crate::assume`) placed on it after the function returns.
+///
+/// ## Safety
+///
+/// Since the generic implementations provided by the crate generates variables from uninitialized memory it is
+/// inherently unsound to execute the code without symex.
 #[inline(never)]
 pub fn any<T: Any>() -> T {
     T::any()
@@ -40,6 +45,11 @@ macro_rules! impl_primitive {
         $(
             impl Any for $type {
                 /// Generates a new symbolic value from uninitialized memory
+                ///
+                /// ### Safety
+                /// 
+                /// Running code that uses uninitialized memory is inherently unsafe, do not run code using the [`any`] function
+                /// without symbolic execution
                 #[inline(always)]
                 fn any() -> Self {
                     unsafe {

--- a/crates/symex_lib/src/any.rs
+++ b/crates/symex_lib/src/any.rs
@@ -1,5 +1,4 @@
 use super::symbolic;
-use std::mem::MaybeUninit;
 
 pub trait Any {
     fn any() -> Self;
@@ -39,7 +38,7 @@ blanket_impl!(isize);
 
 fn internal_any<T: Any>() -> T {
     unsafe {
-        let mut a = MaybeUninit::uninit();
+        let mut a = core::mem::MaybeUninit::uninit();
         symbolic(&mut a);
         a.assume_init()
     }

--- a/crates/symex_lib/src/any.rs
+++ b/crates/symex_lib/src/any.rs
@@ -26,11 +26,6 @@ pub trait Any {
 /// ---
 ///
 /// The symbolic value returned should have no [`assumptions`](crate::assume`) placed on it after the function returns.
-///
-/// ## Safety
-///
-/// Since the generic implementations provided by the crate generates variables from uninitialized memory it is
-/// inherently unsound to execute the code without symex.
 #[inline(never)]
 pub fn any<T: Any>() -> T {
     T::any()
@@ -45,11 +40,6 @@ macro_rules! impl_primitive {
         $(
             impl Any for $type {
                 /// Generates a new symbolic value from uninitialized memory
-                ///
-                /// ### Safety
-                /// 
-                /// Running code that uses uninitialized memory is inherently unsafe, do not run code using the [`any`] function
-                /// without symbolic execution
                 #[inline(always)]
                 fn any() -> Self {
                     unsafe {

--- a/crates/symex_lib/src/any.rs
+++ b/crates/symex_lib/src/any.rs
@@ -42,22 +42,24 @@ pub fn any<T: Any>() -> T {
 /// that is converted to a [`symbolic`] value which is then assumed to be initialized to make the compiler happy.
 macro_rules! impl_primitive {
     ( $($type: ty),+) => {
-        paste::paste!{$(
-                impl Any for $type {
-                    #[doc = "Generates a new symbolic value from uninitialized memory\n\n### Safety\n\n"
-                    "Running code that uses uninitialized memory is inherently unsafe, do not run code using the any function "
-                    "without symbolic execution"]
-                    #[inline(always)]
-                    fn any() -> Self {
-                        unsafe {
-                            let mut a = core::mem::MaybeUninit::uninit();
-                            symbolic(&mut a);
-                            a.assume_init()
-                        }
+        $(
+            impl Any for $type {
+                /// Generates a new symbolic value from uninitialized memory
+                ///
+                /// ### Safety
+                /// 
+                /// Running code that uses uninitialized memory is inherently unsafe, do not run code using the [`any`] function
+                /// without symbolic execution
+                #[inline(always)]
+                fn any() -> Self {
+                    unsafe {
+                        let mut a = core::mem::MaybeUninit::uninit();
+                        symbolic(&mut a);
+                        a.assume_init()
                     }
                 }
-            )+
-        }
+            }
+        )+
     };
 }
 

--- a/crates/symex_lib/src/any.rs
+++ b/crates/symex_lib/src/any.rs
@@ -1,19 +1,15 @@
-//! Any
-//! ---
-//!
-//! This file defines and exports the [`Any`] trait.
-//! This trait provides an interface that allows the user to create a new [`symbolic`] without any prior [`assumptions`](crate::assume) of its value.
 use super::symbolic;
 
-/// Any
+/// Provides the [`any`] operation on the implementor
 /// ---
 ///
-/// The implementers of this trait can be represented as a symbolic value.
-/// # Example implementation
+/// The any operation should return a new [`symbolic`] value with no prior [`assumptions`](crate::assume) placed on the value
+///
+/// ### Example implementation
 /// ```no_run
 /// impl Any for u8 {
 ///     /// Generates a symbolic value a without any assumption of the value.
-///     fn any() -> u8{
+///     fn any() -> Self{
 ///         unsafe{
 ///             let mut a = core::mem::MaybeUninit::uninit();
 ///             symex_lib::symbolic(&mut a);
@@ -26,11 +22,15 @@ pub trait Any {
     fn any() -> Self;
 }
 
-/// any
+/// Creates a new [`symbolic`] value with no prior assumptions.
 /// ---
 ///
-/// Returns a new symbolic value of a type that implements [`Any`].
 /// The symbolic value returned should have no [`assumptions`](crate::assume`) placed on it after the function returns.
+///
+/// ## Safety
+///
+/// Since the generic implementations provided by the crate generates variables from uninitialized memory it is
+/// inherently unsound to execute the code without symex.
 #[inline(never)]
 pub fn any<T: Any>() -> T {
     T::any()
@@ -40,12 +40,13 @@ pub fn any<T: Any>() -> T {
 ///
 /// The blanket implementation provides a method [`any`] that creates a [`uninit`](core::mem::MaybeUninit) value
 /// that is converted to a [`symbolic`] value which is then assumed to be initialized to make the compiler happy.
-#[macro_export]
 macro_rules! impl_primitive {
     ( $($type: ty),+) => {
         paste::paste!{$(
                 impl Any for $type {
-                    #[doc = "Generates a new symbolic value of type [`"[<$type>]"`] value from uninitialized memory"]
+                    #[doc = "Generates a new symbolic value from uninitialized memory\n\n### Safety\n\n"
+                    "Running code that uses uninitialized memory is inherently unsafe, do not run code using the any function "
+                    "without symbolic execution"]
                     #[inline(always)]
                     fn any() -> Self {
                         unsafe {

--- a/crates/symex_lib/src/lib.rs
+++ b/crates/symex_lib/src/lib.rs
@@ -50,7 +50,7 @@ pub fn assume(condition: bool) {
 /// }
 /// ```
 #[inline(never)]
-pub fn symbolic<T>(value: & T) {
+pub fn symbolic<T>(value: &mut T) {
     black_box(value);
 }
 
@@ -101,6 +101,6 @@ pub fn ignore_path() -> ! {
 ///
 /// It is hard to create a "can be anything" value in pure rust, this function tries to trick the
 /// optimizer into not optimizing `value`.
-fn black_box<T>(value: &T) {
-    //*value = unsafe { core::ptr::read(value) }
+fn black_box<T>(value: &mut T) {
+    *value = unsafe { core::ptr::read_volatile(value as *mut T) }
 }

--- a/crates/symex_lib/src/lib.rs
+++ b/crates/symex_lib/src/lib.rs
@@ -1,3 +1,4 @@
+#![no_std]
 mod any;
 
 pub use any::{any, Any};
@@ -93,7 +94,7 @@ impl<T> Valid for &T {
 /// being found.
 #[inline(never)]
 pub fn ignore_path() -> ! {
-    unsafe { std::hint::unreachable_unchecked() }
+    unsafe { core::hint::unreachable_unchecked() }
 }
 
 /// Try and trick the optimizer.

--- a/crates/symex_lib/src/lib.rs
+++ b/crates/symex_lib/src/lib.rs
@@ -50,7 +50,7 @@ pub fn assume(condition: bool) {
 /// }
 /// ```
 #[inline(never)]
-pub fn symbolic<T>(value: &mut T) {
+pub fn symbolic<T>(value: & T) {
     black_box(value);
 }
 
@@ -101,6 +101,6 @@ pub fn ignore_path() -> ! {
 ///
 /// It is hard to create a "can be anything" value in pure rust, this function tries to trick the
 /// optimizer into not optimizing `value`.
-fn black_box<T>(value: &mut T) {
-    *value = unsafe { core::ptr::read_volatile(value as *mut T) }
+fn black_box<T>(value: &T) {
+    //*value = unsafe { core::ptr::read(value) }
 }


### PR DESCRIPTION
# Cleanup of symex_lib::any

This pull request aims to improve the documentation and macro style in symex_lib::any.

## Documentation

I added documentation for the primitive implementations, the public functions, the public trait and the macro making it easier to get to know the code base. These comments may be incorrect, please add a comment if there is any error, and I will gladly fix it.

## Macro cleanup

I changed the macro to be iterative and removed the call to the function `internal_any` since I found it introduced some clutter. If you disagree it is pretty simple to revert.

Depends on #3 

