### PR TITLE
Specified dependencies to fix build.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,11 @@ rand = "0.8.5"
 tracing = "0.1.36"
 tracing-subscriber = "0.3.15"
 object = "0.29.0"
-num_enum = "0.5.7"
+num_enum = "=0.5.7"
 indenter = "0.3"
 colored = "2.0.0"
+toml_edit = "=0.19.14"
+llvm-sys = "=140.0.5"
 
 [workspace]
 members = ["cargo-symex", "examples", "crates/symex_lib", "crates/valid_derive"]

--- a/cargo-symex/Cargo.toml
+++ b/cargo-symex/Cargo.toml
@@ -10,7 +10,7 @@ name = "cargo-symex"
 [dependencies]
 anyhow = "1.0.65"
 cargo-project = "0.3.0"
-clap = { version = "4.0.10", features = ["derive"] }
+clap = { version = "=4.0.10", features = ["derive"] }
 log = "0.4.17"
 regex = "1.6.0"
 rustc_version = "0.4.0"


### PR DESCRIPTION
toml_edit a dependency of num_enum set to fix compatibility with rust 1.64. llvm-sys a dependency of llvm-ir set to roll back to working build.rs.